### PR TITLE
Refactored the special server node out of nodeserver into own packet

### DIFF
--- a/nodes/basenode/connection.go
+++ b/nodes/basenode/connection.go
@@ -63,7 +63,7 @@ func sendWorker(connection net.Conn, send chan interface{}, quit chan bool) {
 		case d := <-send:
 
 			if a, ok := d.(*protocol.Node); ok {
-				a.Uuid = config.Uuid
+				a.SetUuid(config.Uuid)
 				err = encoder.Encode(a.Node())
 			} else {
 				err = encoder.Encode(d)

--- a/nodes/stampzilla-server/logic/logic.go
+++ b/nodes/stampzilla-server/logic/logic.go
@@ -113,7 +113,7 @@ func (l *Logic) ListenForChanges(uuid string) chan string {
 	return c
 }
 
-func (l *Logic) Update(updateChannel chan string, node *serverprotocol.Node) {
+func (l *Logic) Update(updateChannel chan string, node serverprotocol.Node) {
 	state, err := json.Marshal(node.State())
 	if err != nil {
 		log.Error(err)

--- a/nodes/stampzilla-server/logic/logic_test.go
+++ b/nodes/stampzilla-server/logic/logic_test.go
@@ -247,7 +247,7 @@ func TestListenForChanges(t *testing.T) {
 
 	c := logic.ListenForChanges("uuid1234")
 
-	node := &serverprotocol.Node{}
+	node := serverprotocol.NewNode()
 	state := `
 		{
 			"Devices": {
@@ -266,7 +266,9 @@ func TestListenForChanges(t *testing.T) {
 			}
 		}
 	`
-	_ = json.Unmarshal([]byte(state), &node.State_)
+	var tmp interface{}
+	_ = json.Unmarshal([]byte(state), &tmp)
+	node.SetState(tmp)
 
 	logic.Update(c, node)
 	//logic.SetState("uuid1234", state)
@@ -290,7 +292,8 @@ func TestListenForChanges(t *testing.T) {
 			}
 		}
 	`
-	err := json.Unmarshal([]byte(state), &node.State_)
+	err := json.Unmarshal([]byte(state), &tmp)
+	node.SetState(tmp)
 	if err != nil {
 		log.Println(err)
 		return

--- a/nodes/stampzilla-server/metrics/metrics.go
+++ b/nodes/stampzilla-server/metrics/metrics.go
@@ -21,7 +21,7 @@ type Metrics struct {
 }
 
 type UpdatePackage struct {
-	Node  *serverprotocol.Node
+	Node  serverprotocol.Node
 	State map[string]interface{}
 }
 
@@ -51,8 +51,8 @@ func (m *Metrics) worker() {
 
 /* ----[ handle updates ]------------------------------------------*/
 
-func (m *Metrics) Update(node *serverprotocol.Node) {
-	current := structToMetrics(node.Uuid+"_Node_State", node.State())
+func (m *Metrics) Update(node serverprotocol.Node) {
+	current := structToMetrics(node.Uuid()+"_Node_State", node.State())
 	//current := structToMetrics(node.Uuid, node) //DO we want this instead? It will also logg Node.Uuid, Node.Elements etc... i think not!
 
 	data := UpdatePackage{
@@ -63,7 +63,7 @@ func (m *Metrics) Update(node *serverprotocol.Node) {
 	m.queue <- data
 }
 
-func (m *Metrics) update(node *serverprotocol.Node, current map[string]interface{}) {
+func (m *Metrics) update(node serverprotocol.Node, current map[string]interface{}) {
 	if len(m.loggers) == 0 {
 		return
 	}

--- a/nodes/stampzilla-server/metrics/metrics_test.go
+++ b/nodes/stampzilla-server/metrics/metrics_test.go
@@ -219,11 +219,12 @@ func TestUpdate(t *testing.T) {
 	m.AddLogger(l)
 	m.Start()
 
-	node := &serverprotocol.Node{}
+	//node := &serverprotocol.Node{}
+	node := serverprotocol.NewNode()
 	state := getState()
 
-	node.Name = "metrics-test"
-	node.Uuid = "123-123"
+	node.SetName("metrics-test")
+	node.SetUuid("123-123")
 	node.SetState(state)
 
 	wg.Add(1)
@@ -297,11 +298,11 @@ func TestUpdateSameValueVeryFast(t *testing.T) {
 	m.AddLogger(l)
 	m.Start()
 
-	node := &serverprotocol.Node{}
+	node := serverprotocol.NewNode()
 	state := getState()
 
-	node.Name = "metrics-test"
-	node.Uuid = "123-123"
+	node.SetName("metrics-test")
+	node.SetUuid("123-123")
 	node.SetState(state)
 
 	wg.Add(1)

--- a/nodes/stampzilla-server/nodeserver.go
+++ b/nodes/stampzilla-server/nodeserver.go
@@ -58,7 +58,7 @@ func (ns *NodeServer) newNodeConnection(connection net.Conn) {
 	//encoder := json.NewEncoder(os.Stdout)
 	var logicChannel chan string
 	for {
-		var node serverprotocol.Node
+		node := serverprotocol.NewNode()
 		err := decoder.Decode(&node)
 
 		if err != nil {

--- a/nodes/stampzilla-server/protocol/nodes.go
+++ b/nodes/stampzilla-server/protocol/nodes.go
@@ -11,7 +11,18 @@ import (
 //global variable to hold our nodes. Initialized in main
 var nodes *Nodes
 
-type Node struct {
+type Node interface {
+	SetState(interface{})
+	State() interface{}
+	Uuid() string
+	Name() string
+	SetUuid(string)
+	SetName(string)
+	Write(b []byte)
+	SetConn(conn net.Conn)
+}
+
+type node struct {
 	protocol.Node
 	conn net.Conn
 	wait chan bool
@@ -19,19 +30,23 @@ type Node struct {
 	//encoder *json.Encoder
 }
 
-func (n *Node) Conn() net.Conn {
+func NewNode() Node {
+	return &node{}
+}
+
+func (n *node) Conn() net.Conn {
 	n.Lock()
 	defer n.Unlock()
 	return n.conn
 }
 
-func (n *Node) SetConn(conn net.Conn) {
+func (n *node) SetConn(conn net.Conn) {
 	n.Lock()
 	n.conn = conn
 	n.Host = conn.RemoteAddr().String()
 	n.Unlock()
 }
-func (n *Node) Write(b []byte) {
+func (n *node) Write(b []byte) {
 	b = append(b, []byte("\n")...)
 	_, err := n.conn.Write(b)
 	if err != nil {
@@ -42,27 +57,27 @@ func (n *Node) Write(b []byte) {
 
 //  TODO: write tests for Nodes struct (jonaz) <Fri 10 Oct 2014 04:31:22 PM CEST>
 type Nodes struct {
-	nodes map[string]*Node
+	nodes map[string]Node
 	sync.RWMutex
 }
 
 func NewNodes() *Nodes {
 	n := &Nodes{}
-	n.nodes = make(map[string]*Node)
+	n.nodes = make(map[string]Node)
 	return n
 }
 
-func (n *Nodes) ByName(name string) *Node {
+func (n *Nodes) ByName(name string) Node {
 	n.RLock()
 	defer n.RUnlock()
 	for _, node := range n.nodes {
-		if node.Name == name {
+		if node.Name() == name {
 			return node
 		}
 	}
 	return nil
 }
-func (n *Nodes) Search(nameoruuid string) *Node {
+func (n *Nodes) Search(nameoruuid string) Node {
 	if n := n.ByUuid(nameoruuid); n != nil {
 		return n
 	}
@@ -71,7 +86,7 @@ func (n *Nodes) Search(nameoruuid string) *Node {
 	}
 	return nil
 }
-func (n *Nodes) ByUuid(uuid string) *Node {
+func (n *Nodes) ByUuid(uuid string) Node {
 	n.RLock()
 	defer n.RUnlock()
 	if node, ok := n.nodes[uuid]; ok {
@@ -79,15 +94,20 @@ func (n *Nodes) ByUuid(uuid string) *Node {
 	}
 	return nil
 }
-func (n *Nodes) All() map[string]*Node {
+func (n *Nodes) All() map[string]Node {
 	n.RLock()
 	defer n.RUnlock()
-	return n.nodes
+	r := make(map[string]Node)
+	for k, v := range n.nodes {
+		r[k] = v
+	}
+	return r
+	//return n.nodes
 }
-func (n *Nodes) Add(node *Node) {
+func (n *Nodes) Add(node Node) {
 	n.Lock()
 	defer n.Unlock()
-	n.nodes[node.Uuid] = node
+	n.nodes[node.Uuid()] = node
 }
 func (n *Nodes) Delete(uuid string) {
 	n.Lock()

--- a/nodes/stampzilla-server/protocol/nodes_test.go
+++ b/nodes/stampzilla-server/protocol/nodes_test.go
@@ -9,9 +9,9 @@ import (
 func TestSearch(t *testing.T) {
 	nodes := NewNodes()
 
-	node := &Node{}
-	node.Name = "Test"
-	node.Uuid = "testuuid"
+	node := &node{}
+	node.SetName("Test")
+	node.SetUuid("testuuid")
 
 	nodes.Add(node)
 
@@ -33,9 +33,9 @@ func TestSearch(t *testing.T) {
 }
 func TestDelete(t *testing.T) {
 	nodes := NewNodes()
-	node := &Node{}
-	node.Name = "Test"
-	node.Uuid = "testuuid"
+	node := &node{}
+	node.SetName("Test")
+	node.SetUuid("testuuid")
 	nodes.Add(node)
 
 	nodes.Delete("testuuid")
@@ -50,9 +50,9 @@ func TestWrite(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close()
 
-	node := &Node{}
-	node.Name = "Test"
-	node.Uuid = "testuuid"
+	node := &node{}
+	node.SetName("Test")
+	node.SetUuid("testuuid")
 	node.SetConn(cli)
 
 	go func() {

--- a/nodes/stampzilla-server/servernode/servernode.go
+++ b/nodes/stampzilla-server/servernode/servernode.go
@@ -1,0 +1,81 @@
+package servernode
+
+import (
+	"net"
+	"strconv"
+
+	serverprotocol "github.com/stampzilla/stampzilla-go/nodes/stampzilla-server/protocol"
+	"github.com/stampzilla/stampzilla-go/protocol"
+)
+
+type Node struct {
+	protocol.Node
+	State_       map[string]interface{} `json:"State"`
+	logicChannel chan string
+}
+
+func New(uuid string, logicChannel chan string) serverprotocol.Node {
+	node := &Node{
+		State_:       make(map[string]interface{}),
+		logicChannel: logicChannel,
+	}
+	node.SetName("server")
+	return node
+}
+func (self *Node) SetConn(conn net.Conn) {
+}
+func (n *Node) Write(b []byte) {
+}
+
+func (self *Node) LogicChannel() chan string {
+	self.RLock()
+	defer self.RUnlock()
+	return self.logicChannel
+}
+
+func (self *Node) State() interface{} {
+	self.RLock()
+	defer self.RUnlock()
+	return self.State_
+}
+
+func (self *Node) Set(key string, value interface{}) {
+	self.Lock()
+	defer self.Unlock()
+	self.State_[key] = cast(value)
+}
+
+func (self *Node) Reset(key string) {
+	switch self.State_[key].(type) {
+	case int:
+		self.Set(key, 0)
+	case float64:
+		self.Set(key, 0.0)
+	case string:
+		self.Set(key, "")
+	case bool:
+		self.Set(key, 0)
+	}
+}
+
+func cast(s interface{}) interface{} {
+	switch v := s.(type) {
+	case int:
+		return v
+		//return strconv.Itoa(v)
+	case float64:
+		//return strconv.FormatFloat(v, 'f', -1, 64)
+		return v
+	case string:
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+		return v
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	}
+	return ""
+}

--- a/protocol/node.go
+++ b/protocol/node.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Node struct { /*{{{*/
-	Name     string
-	Uuid     string
+	Name_    string `json:"Name"`
+	Uuid_    string `json:"Uuid"`
 	Host     string
 	Actions  []*Action
 	Layout   []*Layout
@@ -22,9 +22,7 @@ type Node struct { /*{{{*/
 
 func NewNode(name string) *Node {
 	return &Node{
-		Name:    name,
-		Uuid:    "",
-		Host:    "",
+		Name_:   name,
 		Actions: []*Action{},
 		Layout:  []*Layout{}}
 }
@@ -65,6 +63,26 @@ func (n *Node) Node() *Node {
 	n.RLock()
 	defer n.RUnlock()
 	return n
+}
+func (n *Node) Uuid() string {
+	n.RLock()
+	defer n.RUnlock()
+	return n.Uuid_
+}
+func (n *Node) Name() string {
+	n.RLock()
+	defer n.RUnlock()
+	return n.Name_
+}
+func (n *Node) SetUuid(uuid string) {
+	n.Lock()
+	defer n.Unlock()
+	n.Uuid_ = uuid
+}
+func (n *Node) SetName(name string) {
+	n.Lock()
+	defer n.Unlock()
+	n.Name_ = name
 }
 
 func (n *Node) JsonEncode() (string, error) {


### PR DESCRIPTION
Now its easier to write tests for both nodeserver and servernode.
We have cleaner code. 

To solve this i introduced the serverprotocol Node interface. 
We might move that to the "base" protocol later if this works fine. 

Tip in the future: always think behavior and use interfaces. Its even possible to compose bigger interfaces from smaller ones. 