### PR TITLE
Moved goveralls to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ install:
 
 script: 
   - go test -v `go list ./... | grep -v telldus-events | grep -v stampzilla-hidcommander`
-  - bash coverage  
+  - bash coverage
+after_success:
   - goveralls -coverprofile=./gover.coverprofile -service travis-ci


### PR DESCRIPTION
This change is to fix the issue when coveralls is down. This way we dont get a broken build if coveralls is down.