### PR TITLE
Fix GA on/off commands

### DIFF
--- a/nodes/stampzilla-google-assistant/smarthome.go
+++ b/nodes/stampzilla-google-assistant/smarthome.go
@@ -112,7 +112,7 @@ func (shh *SmartHomeHandler) executeHandler(req *googleassistant.Request) *googl
 				}
 
 				dev := shh.deviceList.Get(devID)
-				if dev == nil || dev.Type != "light" {
+				if dev == nil {
 					deviceNotFound.IDs = append(deviceNotFound.IDs, googleDev.ID)
 					continue
 				}


### PR DESCRIPTION
Sync function filters on traits so we should not filter the commands