### PR TITLE
Up go to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
       - libasound2-dev
 
 go:
-- 1.13
+- 1.15
 install:
 - go get -d -t -v ./...
 
@@ -30,5 +30,5 @@ deploy:
   on:
     tags: true
     repo: stampzilla/stampzilla-go
-    condition: $TRAVIS_GO_VERSION =~ ^1\.13
+    condition: $TRAVIS_GO_VERSION =~ ^1\.15
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/RangelReale/osin v1.0.1
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/cloudfoundry/gosigar v1.1.0
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
@@ -23,7 +22,6 @@ require (
 	github.com/go-playground/validator/v10 v10.3.0 // indirect
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0 // indirect
-	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/cel-go v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry/gosigar v1.1.0 h1:V/dVCzhKOdIU3WRB5inQU20s4yIgL9Dxx/Mhi0SF8eM=
 github.com/cloudfoundry/gosigar v1.1.0/go.mod h1:3qLfc2GlfmwOx2+ZDaRGH3Y9fwQ0sQeaAleo2GV5pH0=
-github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
-github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.1.0 h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4PxnR5lg=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -63,6 +59,7 @@ github.com/go-gl/gl v0.0.0-20180407155706-68e253793080/go.mod h1:482civXOzJJCPzJ
 github.com/go-gl/glfw v0.0.0-20180426074136-46a8d530c326/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
@@ -78,8 +75,6 @@ github.com/goburrow/modbus v0.1.0 h1:DejRZY73nEM6+bt5JSP6IsFolJ9dVcqxsYbpLbeW/ro
 github.com/goburrow/modbus v0.1.0/go.mod h1:Kx552D5rLIS8E7TyUwQ/UdHEqvX5T8tyiGBTlzMcZBg=
 github.com/goburrow/serial v0.1.0 h1:v2T1SQa/dlUqQiYIT8+Cu7YolfqAi3K96UmhwYyuSrA=
 github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=
-github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
-github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -109,6 +104,7 @@ github.com/google/cel-spec v0.3.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -150,8 +146,6 @@ github.com/jonaz/astrotime v0.0.0-20150127084258-5d2b676e5047 h1:H116DwaFx14mDVP
 github.com/jonaz/astrotime v0.0.0-20150127084258-5d2b676e5047/go.mod h1:2IUrxSOG2BFL1TPEVaMvOL/b0fJcldiGXyw8OWZAUM4=
 github.com/jonaz/cron v0.0.0-20190121203350-e9ab53dd31db h1:aL5VtwT2HOGwv1/3vFSs5NcpuNmhxEnDqncncO15fZY=
 github.com/jonaz/cron v0.0.0-20190121203350-e9ab53dd31db/go.mod h1:eP+FmjzGNohqBN8DYZfBc/XhSg7PT26pdjopqdBfh6k=
-github.com/jonaz/ginlogrus v0.0.0-20191003061925-e99fa8b4915c h1:hK9O1NflY5eHUq77dkIA7vL3tHpY270Sk1TgqH9wqXw=
-github.com/jonaz/ginlogrus v0.0.0-20191003061925-e99fa8b4915c/go.mod h1:FMy6Xd1eGEvmKOIAJAVZlp+azKxMhED8I4BExTVcYac=
 github.com/jonaz/ginlogrus v0.0.0-20191118094232-2f4da50f5dd6 h1:eSDBw96rsjHo6ul9fMfUn/1I3iUbR5PWt/mj46Ksxcc=
 github.com/jonaz/ginlogrus v0.0.0-20191118094232-2f4da50f5dd6/go.mod h1:FMy6Xd1eGEvmKOIAJAVZlp+azKxMhED8I4BExTVcYac=
 github.com/jonaz/goenocean v0.0.0-20190218201525-96fde8f44745 h1:XnuDgGQKEfPcTqcA7tvLIMn0VPd1K6bwtF86KZcAsIQ=
@@ -172,8 +166,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7 h1:SWlt7BoQNASbhTUD0Oy5yysI2seJ7vWuGUp///OM4TM=
 github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7/go.mod h1:Y2SaZf2Rzd0pXkLVhLlCiAXFCLSXAIbTKDivVgff/AM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -195,8 +187,6 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
-github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
-github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -232,8 +222,6 @@ github.com/posener/wstest v0.0.0-20180217133618-28272a7ea048 h1:XJ1bEwzKDbW33q70
 github.com/posener/wstest v0.0.0-20180217133618-28272a7ea048/go.mod h1:cjC8eRbwXrr5m2069dsjp7l7b0gWqFwMTUBDLNvVqho=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438/go.mod h1:wTPjTepVu7uJBYgZ0SdWHQlIas582j6cn2jgk4DDdlg=
-github.com/rakyll/statik v0.1.6 h1:uICcfUXpgqtw2VopbIncslhAmE5hwc4g20TEyEENBNs=
-github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -277,8 +265,6 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vapourismo/knx-go v0.0.0-20190917200938-c1313fa7e9ca h1:w8z3ZMypVOPRjAEOVhMStngaGTdvz0gIbpggsuCZ4GE=
-github.com/vapourismo/knx-go v0.0.0-20190917200938-c1313fa7e9ca/go.mod h1:7+aWBsUJCo9OQRCgTypRmIQW9KKKcPMjtrdnYIBsS70=
 github.com/vapourismo/knx-go v0.0.0-20200924173532-6ed2bf1e51e6 h1:dTVtrvVaFZ53hnIHedtuvCgQdoukoJa6yGZB5oFogZY=
 github.com/vapourismo/knx-go v0.0.0-20200924173532-6ed2bf1e51e6/go.mod h1:7+aWBsUJCo9OQRCgTypRmIQW9KKKcPMjtrdnYIBsS70=
 golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -311,6 +297,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -322,9 +309,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb h1:ZxSglHghKPYD8WDeRUzRJrUJtDF0PxsTUSxyqr9/5BI=
-golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
@@ -338,13 +322,12 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 h1:4HYDjxeNXAOTv3o1N2tjo8UUSlhQgAD52FVkwxnWgM8=
-google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
@@ -378,8 +361,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/stampzilla/clihandler.go
+++ b/stampzilla/clihandler.go
@@ -68,7 +68,6 @@ func (t *cliHandler) List(c *cli.Context) error {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 	releases, _, err := client.Repositories.ListReleases(ctx, "stampzilla", "stampzilla-go", &github.ListOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -160,12 +159,14 @@ func (t *cliHandler) Restart(c *cli.Context) error {
 
 	return r.Restart(c.Args()...)
 }
+
 func (t *cliHandler) Status(c *cli.Context) error {
 	requireRoot()
 	r := getRunner(c)
 	defer r.Close()
 	return r.Status()
 }
+
 func (t *cliHandler) Disable(c *cli.Context) error {
 	requireRoot()
 	r := &runner.Systemd{}

--- a/stampzilla/installer/binary/installer.go
+++ b/stampzilla/installer/binary/installer.go
@@ -26,6 +26,7 @@ func NewInstaller() *Installer {
 func (t *Installer) Prepare() error {
 	return nil
 }
+
 func (t *Installer) Install(nodes ...string) error {
 	if len(nodes) == 0 {
 		return fmt.Errorf("Please specify which nodes you like to install. (ex 'stampzilla install server example')")
@@ -39,6 +40,7 @@ func (t *Installer) Install(nodes ...string) error {
 		return false
 	})
 }
+
 func (t *Installer) Update(nodes ...string) error {
 	return download(nodes, func(a github.ReleaseAsset) bool {
 		_, err := os.Stat(getFilePath(a))
@@ -50,7 +52,7 @@ func (t *Installer) Update(nodes ...string) error {
 	})
 }
 
-// Download downloads a file and takes a callback. If callback returns true, skip download
+// Download downloads a file and takes a callback. If callback returns true, skip download.
 func download(nodes []string, cb ...func(github.ReleaseAsset) bool) error {
 	releases := GetReleases()
 

--- a/stampzilla/installer/binary/releases.go
+++ b/stampzilla/installer/binary/releases.go
@@ -10,7 +10,6 @@ func GetReleases() []*github.RepositoryRelease {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 	releases, _, err := client.Repositories.ListReleases(ctx, "stampzilla", "stampzilla-go", &github.ListOptions{})
-
 	if err != nil {
 		return nil
 	}
@@ -19,7 +18,7 @@ func GetReleases() []*github.RepositoryRelease {
 
 	////commits, _, err := client.Repositories.ListCommits(ctx, "stampzilla", "stampzilla-go"
 
-	//url := "https://api.github.com/repos/stampzilla/stampzilla-go/releases"
+	// url := "https://api.github.com/repos/stampzilla/stampzilla-go/releases"
 
 	//req, err := http.NewRequest("GET", url, nil)
 	//if err != nil {
@@ -27,7 +26,7 @@ func GetReleases() []*github.RepositoryRelease {
 	//return []Release{}
 	//}
 
-	//client := &http.Client{}
+	// client := &http.Client{}
 
 	//resp, err := client.Do(req)
 	//if err != nil {
@@ -35,13 +34,13 @@ func GetReleases() []*github.RepositoryRelease {
 	//return []Release{}
 	//}
 
-	//defer resp.Body.Close()
+	// defer resp.Body.Close()
 
-	//var releases []Release
+	// var releases []Release
 
 	//if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
 	//log.Println(err)
 	//}
 
-	//return releases
+	// return releases
 }

--- a/stampzilla/installer/config.go
+++ b/stampzilla/installer/config.go
@@ -14,6 +14,7 @@ type Daemon struct {
 	Name      string `json:"name"`
 	Autostart bool   `json:"autostart"`
 }
+
 type Config struct {
 	Daemons []*Daemon `json:"daemons"`
 }
@@ -26,6 +27,7 @@ func (c *Config) GetConfigForNode(name string) *Daemon {
 	}
 	return nil
 }
+
 func (c *Config) GetAutostartingNodes() []*Daemon {
 	var daemons []*Daemon
 	for _, d := range c.Daemons {
@@ -35,6 +37,7 @@ func (c *Config) GetAutostartingNodes() []*Daemon {
 	}
 	return daemons
 }
+
 func (c *Config) GenerateDefault() error {
 	nodes, err := ioutil.ReadDir("/home/stampzilla/go/src/github.com/stampzilla/stampzilla-go/nodes/")
 	if err != nil {
@@ -70,6 +73,7 @@ func (c *Config) SaveToFile(filepath string) error {
 	out.WriteTo(configFile)
 	return nil
 }
+
 func (c *Config) ReadConfigFromFile(filepath string) error {
 	configFile, err := os.Open(filepath)
 	if err != nil {

--- a/stampzilla/installer/pidfile.go
+++ b/stampzilla/installer/pidfile.go
@@ -13,7 +13,7 @@ func (f *PidFile) String() string {
 	return string(*f)
 }
 
-//Read the pidfile.
+// Read the pidfile.
 func (f *PidFile) Read() int {
 	data, err := ioutil.ReadFile(string(*f))
 	if err != nil {
@@ -27,7 +27,7 @@ func (f *PidFile) Read() int {
 	return int(pid)
 }
 
-//Write the pidfile.
+// Write the pidfile.
 func (f *PidFile) write(data int) error {
 	err := ioutil.WriteFile(string(*f), []byte(strconv.Itoa(data)), 0660)
 	if err != nil {
@@ -36,7 +36,7 @@ func (f *PidFile) write(data int) error {
 	return nil
 }
 
-//Delete the pidfile
+//Delete the pidfile.
 func (f *PidFile) delete() bool {
 	_, err := os.Stat(string(*f))
 	if err != nil {

--- a/stampzilla/installer/process.go
+++ b/stampzilla/installer/process.go
@@ -104,7 +104,7 @@ func Run(head string, parts ...string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command(head, parts...)
-	//cmd.Env = []string{"GOPATH=$HOME/go", "PATH=$PATH:$GOPATH/bin"}
+	// cmd.Env = []string{"GOPATH=$HOME/go", "PATH=$PATH:$GOPATH/bin"}
 	cmd.Env = []string{
 		"GOPATH=/home/stampzilla/go",
 		"PATH=" + os.Getenv("PATH"),

--- a/stampzilla/installer/source/installer.go
+++ b/stampzilla/installer/source/installer.go
@@ -25,9 +25,11 @@ func NewInstaller() *Installer {
 func (t *Installer) Prepare() error {
 	return nil
 }
+
 func (t *Installer) Install(nodes ...string) error {
 	return build(nodes, false)
 }
+
 func (t *Installer) Update(nodes ...string) error {
 	return build(nodes, true)
 }
@@ -69,7 +71,12 @@ func GoGet(url string) error {
 		return fmt.Errorf("LookPath Error: %s", err.Error())
 	}
 
-	_, err = Run(gobin, "get", "-u", "-d", url)
+	_, err = Run(gobin, "get", "-u", "-d", "github.com/stampzilla/stampzilla-go")
+	if err != nil {
+		return err
+	}
+	os.Chdir(filepath.Join("/home", "stampzilla", "go", "src", "github.com", "stampzilla", "stampzilla-go"))
+	_, err = Run(gobin, "mod", "download")
 	if err != nil {
 		return err
 	}
@@ -92,7 +99,7 @@ func getArgs(binName string) []string {
 		filepath.Join("/home", "stampzilla", "go", "bin", binName),
 		filepath.Join("/home", "stampzilla", "go", "src", "github.com", "stampzilla", "stampzilla-go", "nodes", binName),
 	}
-	//fmt.Println(strings.Join(m, "\n"))
+	// fmt.Println(strings.Join(m, "\n"))
 	return m
 }
 

--- a/stampzilla/installer/user.go
+++ b/stampzilla/installer/user.go
@@ -32,6 +32,7 @@ func CreateUser(username string) {
 		"created": "true",
 	}).Info(action)
 }
+
 func userExists(username string) bool {
 	_, err := Run("id", "-u", username)
 	if err != nil {
@@ -42,7 +43,7 @@ func userExists(username string) bool {
 
 func CreateDirAsUser(directory string, username string) {
 	action := "Check directory " + directory
-	var created = false
+	created := false
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 		err := os.MkdirAll(directory, 0777)

--- a/stampzilla/runner/bare.go
+++ b/stampzilla/runner/bare.go
@@ -17,6 +17,7 @@ type Bare struct {
 
 func (t *Bare) Close() {
 }
+
 func (t *Bare) Restart(nodes ...string) error {
 	err := t.Stop(nodes...)
 	if err != nil {
@@ -25,6 +26,7 @@ func (t *Bare) Restart(nodes ...string) error {
 
 	return t.Start(nodes...)
 }
+
 func (t *Bare) Start(nodes ...string) error {
 	cfg := installer.Config{}
 	cfg.ReadConfigFromFile("/etc/stampzilla/nodes.conf")
@@ -52,7 +54,7 @@ func (t *Bare) Stop(nodes ...string) error {
 		return nil
 	}
 
-	//stop all running stampzilla processes
+	// stop all running stampzilla processes
 	processes := t.getRunningProcesses()
 	for _, p := range processes {
 		p.Stop()
@@ -99,7 +101,7 @@ func (b *Bare) getRunningProcesses() []*installer.Process {
 		processes = append(processes, process)
 	}
 
-	//change to this when you have time: http://linux.die.net/man/5/proc /proc/pid/stat
+	// change to this when you have time: http://linux.die.net/man/5/proc /proc/pid/stat
 	ps, err := installer.Run("ps", "aux")
 	if err != nil {
 		fmt.Println(err)
@@ -120,8 +122,8 @@ func (b *Bare) getRunningProcesses() []*installer.Process {
 			var process *installer.Process
 			for _, p1 := range processes {
 				process = nil
-				//fmt.Println(p[4], p1.Pid)
-				//fmt.Printf("%#v\n", p)
+				// fmt.Println(p[4], p1.Pid)
+				// fmt.Printf("%#v\n", p)
 				if strings.Contains(pslineslice[1], strconv.Itoa(p1.Pid)) {
 					process = p1
 					break
@@ -131,18 +133,18 @@ func (b *Bare) getRunningProcesses() []*installer.Process {
 			if process == nil {
 				continue
 			}
-			//fmt.Println("NAME", p[len(p)-1])
-			//fmt.Println("CPU", p[6])
-			//fmt.Println("MEM", p[8])
-			//process := &Process{Name: p[len(p)-1], Command: p[len(p)-1]}
-			//fmt.Printf("%#v\n", pslineslice)
+			// fmt.Println("NAME", p[len(p)-1])
+			// fmt.Println("CPU", p[6])
+			// fmt.Println("MEM", p[8])
+			// process := &Process{Name: p[len(p)-1], Command: p[len(p)-1]}
+			// fmt.Printf("%#v\n", pslineslice)
 			process.Name = filepath.Base(pslineslice[len(pslineslice)-1])
 			process.Command = pslineslice[len(pslineslice)-1]
 			process.Status = &installer.ProcessStatus{true, pslineslice[2], pslineslice[3]}
 		}
 	}
 
-	//remove not found processes from the list.
+	// remove not found processes from the list.
 	for index, p := range processes {
 		if p.Name == "" {
 			if len(processes) > index+1 {

--- a/stampzilla/runner/systemd.go
+++ b/stampzilla/runner/systemd.go
@@ -93,7 +93,7 @@ func (sd *Systemd) Stop(nodes ...string) error {
 		return err
 	}
 
-	//stop all running stampzilla processes
+	// stop all running stampzilla processes
 	for _, p := range units {
 		logrus.Info("Stopping ", p.Name)
 		ch := make(chan string)
@@ -106,7 +106,7 @@ func (sd *Systemd) Stop(nodes ...string) error {
 	return nil
 }
 
-// Restart restarts currencly running nodes
+// Restart restarts currencly running nodes.
 func (sd *Systemd) Restart(nodes ...string) error {
 	conn := sd.dbus()
 	units, err := conn.ListUnitsByPatterns([]string{"active", "activating", "failed"}, []string{"stampzilla-*"})


### PR DESCRIPTION
also fixed stampzilla build command to use modules cache. We had dependency on removed git repo and build failed in legacy mod mode. 